### PR TITLE
Move train_all_steer inside bair_car_data

### DIFF
--- a/Data.py
+++ b/Data.py
@@ -32,9 +32,9 @@ class Data:
         self.train_all_steer_path = ARGS.data_path + '/train_all_steer'
         self.val_all_steer_path = ARGS.data_path + '/val_all_steer'
         print('loading train_valid_data_moments...')
-        self.train_index = DataIndex(lo(self.train_all_steer_path)), -1, 0)
+        self.train_index = DataIndex(lo(self.train_all_steer_path), -1, 0)
         print('loading val_valid_data_moments...')
-        self.val_index = DataIndex(lo(opjD(self.val_all_steer_path)), -1, 0)
+        self.val_index = DataIndex(lo(self.val_all_steer_path), -1, 0)
 
     @staticmethod
     def get_data(run_code, seg_num, offset):

--- a/Data.py
+++ b/Data.py
@@ -29,12 +29,12 @@ class Data:
                                        self.hdf5_runs_path)
 
         # Load data indexes for training and validation
-        self.train_all_steer_path = ARGS.data_path + '/train_all_steer'
-        self.val_all_steer_path = ARGS.data_path + '/val_all_steer'
+        train_all_steer_path = ARGS.data_path + '/train_all_steer'
+        val_all_steer_path = ARGS.data_path + '/val_all_steer'
         print('loading train_valid_data_moments...')
-        self.train_index = DataIndex(lo(self.train_all_steer_path), -1, 0)
+        self.train_index = DataIndex(lo(train_all_steer_path), -1, 0)
         print('loading val_valid_data_moments...')
-        self.val_index = DataIndex(lo(self.val_all_steer_path), -1, 0)
+        self.val_index = DataIndex(lo(val_all_steer_path), -1, 0)
 
     @staticmethod
     def get_data(run_code, seg_num, offset):

--- a/Data.py
+++ b/Data.py
@@ -29,10 +29,12 @@ class Data:
                                        self.hdf5_runs_path)
 
         # Load data indexes for training and validation
+        self.train_all_steer_path = ARGS.data_path + '/train_all_steer'
+        self.val_all_steer_path = ARGS.data_path + '/val_all_steer'
         print('loading train_valid_data_moments...')
-        self.train_index = DataIndex(lo(opjD('train_all_steer')), -1, 0)
+        self.train_index = DataIndex(lo(self.train_all_steer_path)), -1, 0)
         print('loading val_valid_data_moments...')
-        self.val_index = DataIndex(lo(opjD('val_all_steer')), -1, 0)
+        self.val_index = DataIndex(lo(opjD(self.val_all_steer_path)), -1, 0)
 
     @staticmethod
     def get_data(run_code, seg_num, offset):


### PR DESCRIPTION
On the newly imaged bdd3, I've moved train_all_steer.pkl and val_all_steer.pkl inside bair_car_data directory so that the dataset is self-contained. This PR reflects that change.