### PR TITLE
Switch to Python 3.6

### DIFF
--- a/preprocessing/Utils.py
+++ b/preprocessing/Utils.py
@@ -1,0 +1,105 @@
+"""Utility classes for training."""
+import os
+import operator
+import time
+from Parameters import ARGS
+from libs.utils2 import Timer, d2s
+from libs.vis2 import mi
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+
+class MomentCounter:
+    """Notify after N Data Moments Passed"""
+
+    def __init__(self, n):
+        self.start = 0
+        self.n = n
+
+    def step(self, data_index):
+        if data_index.ctr - self.start >= self.n:
+            self.start = data_index.ctr
+            return True
+        return False
+
+
+class LossLog:
+    """Keep Track of Loss, can be used within epoch or for per epoch."""
+
+    def __init__(self):
+        self.log = []
+        self.ctr = 0
+        self.total_loss = 0
+
+    def add(self, ctr, loss):
+        self.log.append((ctr, loss))
+        self.total_loss += loss
+        self.ctr += 1
+
+    def average(self):
+        return self.total_loss / (self.ctr * 1.)
+
+    def export_csv(self, filename):
+        np.savetxt(
+            filename,
+            np.array(self.log),
+            header='Counter,Loss',
+            delimiter=",",
+            comments='')
+
+
+class RateCounter:
+    """Calculate rate of process in Hz"""
+
+    def __init__(self):
+        self.rate_ctr = 0
+        self.rate_timer_interval = 10.0
+        self.rate_timer = Timer(self.rate_timer_interval)
+
+    def step(self):
+        self.rate_ctr += 1
+        if self.rate_timer.check():
+            print('rate = ' + str(ARGS.batch_size * self.rate_ctr /
+                                  self.rate_timer_interval) + 'Hz')
+            self.rate_timer.reset()
+            self.rate_ctr = 0
+
+
+def save_net(weights_file_name, net):
+    torch.save(
+        net.state_dict(),
+        os.path.join(
+            ARGS.save_path,
+            weights_file_name +
+            '.weights'))
+
+    # Next, save for inference (creates ['net'] and moves net to GPU #0)
+    weights = {'net': net.state_dict().copy()}
+    for key in weights['net']:
+        weights['net'][key] = weights['net'][key].cuda(device=0)
+    torch.save(weights,
+               os.path.join(ARGS.save_path, weights_file_name + '.infer'))
+
+
+def display_sort_data_moment_loss(data_moment_loss_record, data):
+    sorted_data_moment_loss_record = sorted(data_moment_loss_record.items(),
+                                            key=operator.itemgetter(1))
+    low_loss_range = range(20)
+    high_loss_range = range(-1, -20, -1)
+
+    for i in low_loss_range + high_loss_range:
+        l = sorted_data_moment_loss_record[i]
+        run_code, seg_num, offset = sorted_data_moment_loss_record[i][0][0]
+        t = sorted_data_moment_loss_record[i][0][1]
+        o = sorted_data_moment_loss_record[i][0][2]
+
+        sorted_data = data.get_data(run_code, seg_num, offset)
+        plt.figure(22)
+        plt.clf()
+        plt.ylim(0, 1)
+        plt.plot(t, 'r.')
+        plt.plot(o, 'g.')
+        plt.plot([0, 20], [0.5, 0.5], 'k')
+        mi(sorted_data['right'][0, :, :], 23, img_title=d2s(l[1]))
+        plt.pause(1)

--- a/preprocessing/libs/Segment_Data.py
+++ b/preprocessing/libs/Segment_Data.py
@@ -1,8 +1,8 @@
 """Helper functions to load segment data from runs."""
 #from kzpy3.teg9.data.utils.preprocess_bag_data import *
 #from kzpy3.teg9.data.utils.Bag_File import *
-from progress import *
-from vis2 import *
+from .progress import *
+from .vis2 import *
 import sys
 
 
@@ -133,7 +133,7 @@ def load_animate_hdf5(path, start_at_time=0):
                 bar_color = [255, 0, 255]  # Purple
 
             else:
-                print s[n][state][i]
+                print(s[n][state][i])
                 # black, show not be seen, indicates state 2 or 4.
                 bar_color = [0, 0, 0]
             if i < 2:

--- a/preprocessing/libs/progress.py
+++ b/preprocessing/libs/progress.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from utils2 import *
+from .utils2 import *
 ###########
 '''
 e.g.

--- a/preprocessing/libs/vis2.py
+++ b/preprocessing/libs/vis2.py
@@ -1,5 +1,5 @@
 """Visualization utilities imported from kzpy3."""
-from utils2 import *
+from .utils2 import *
 
 import matplotlib
 try:

--- a/training/Datasets.py
+++ b/training/Datasets.py
@@ -12,9 +12,9 @@ class MergedDataset(data.Dataset):
         self.start = []
         self.end = []
         self.total_count = 0
-        self.minlen = sys.maxint
+        self.minlen = float("inf")
         for f in hdf5_list:
-            print f
+            print(f)
             h5_file = h5py.File(f, 'r')
             self.datasets.append(h5_file)
             self.start.append(self.total_count)


### PR DESCRIPTION
Only a couple tiny changes were required since we already wrote the code to be very portable. Since Python 2.7 is going to be obsoleted at some point and Python 3 is the new standard, we should be using the Python 3 standard.