### PR TITLE
Got Aruco Dataset Parsing and Training Working

### DIFF
--- a/ArucoDataset.py
+++ b/ArucoDataset.py
@@ -1,4 +1,5 @@
 import numpy as np
+import time
 import h5py
 import torch
 import torch.utils.data as data
@@ -8,18 +9,21 @@ import os
 import matplotlib.pyplot as plt
 
 
-class ArucoDataset(data.Dataset):
+class Dataset(data.Dataset):
     def __init__(self, data_folder_dir, require_one, ignore_list, stride=10):
         self.runs = os.walk(os.path.join(data_folder_dir, 'processed_h5py')).next()[1]
         shuffle(self.runs)  # shuffle each epoch to allow shuffle False
         self.run_files = []
 
         # Initialize List of Files
+        self.invisible = []
         self.visible = []
         self.total_length = 0 
         self.full_length = 0 
 
+        run_num = 0
         for run in self.runs:
+            run_num += 1
             segs_in_run = os.walk(os.path.join(data_folder_dir, 'processed_h5py', run)).next()[1]
             shuffle(segs_in_run)  # shuffle on each epoch to allow shuffle False
 
@@ -47,21 +51,37 @@ class ArucoDataset(data.Dataset):
             if ignored:
                 continue
 
-            print 'Loading Run ' + run
+            print 'Loading Run {}/{}'.format(run_num, len(self.runs))
             for seg in segs_in_run:
+                images = h5py.File(
+                    os.path.join(
+                        data_folder_dir,
+                        'processed_h5py',
+                        run,
+                        seg,
+                        'images.h5py'),
+                    'r')
 
-                images = h5py.File('/hostroot/data/dataset/bair_car_data_new_28April2017/h5py/'+run+'/flip_images.h5py')
-                metadata = h5py.File('/hostroot/data/dataset/bair_car_data_new_28April2017/h5py/'+run+'/left_timestamp_metadata.h5py')
-                aruco_trajectories = h5py.File('/hostroot/data/dataset/Aruco_Steering_Trajectories/h5py/'+run+'.h5py')
+                metadata = h5py.File(
+                    os.path.join(data_folder_dir,
+                        'processed_h5py',
+                         run,
+                         seg,
+                         'metadata.h5py'),
+                    'r')
 
 
-                length = images['left']['vals'].shape[0]
-                self.run_files.append({'images': images, 'metadata': metadata, 'run_labels' : run_labels, 'aruco_trajectories' : aruco_trajectories})
-                self.visible.append(
-                    self.total_length)  # Get rid of the first 7 frames as starting points
-                self.total_length += 4 * (length - (10 * stride - 1) - 7)
+                length = len(images['left'])
+                self.run_files.append({'images': images, 'metadata': metadata, 'run_labels' : run_labels})
 
-        # self.visible = self.run_list[:-1]  # Get rid of last element (speed)
+                self.visible.append(self.total_length)  # visible indicies
+
+                # invisible is not actually used at all, but is extremely useful
+                # for debugging indexing problems and gives very little slowdown
+                self.invisible.append(self.full_length + 7) # actual indicies mapped
+
+                self.total_length += 4 * (length - 7)
+                self.full_length += length
 
         # Create row gradient
         self.row_gradient = torch.FloatTensor(94, 168)
@@ -74,55 +94,36 @@ class ArucoDataset(data.Dataset):
             self.col_gradient[:, col] = col / 167.
 
         self.stride = stride
+        self.aruco_idx_to_key = ['cwdirect', 'ccwdirect', 'cwfollow', 'ccwfollow']
 
     def __getitem__(self, index):
         run_idx, t = self.create_map(index)
-
-        # Convert t into Aruco trajectory indices
         camera_t = t // 4
         aruco_idx = t % 4
+        aruco_key = self.aruco_idx_to_key[aruco_idx]
 
         list_camera_input = []
 
         list_camera_input.append(
             torch.from_numpy(
                 self.run_files[
-                    run_idx]['images']['left'][
-                        camera_t - 7]))
+                    run_idx]['images']['left'][camera_t - 7]))
 
         for delta_time in range(6, -1, -1):
             list_camera_input.append(
                 torch.from_numpy(
                     self.run_files[
-                        run_idx][
-                            'images'][
-                        'left'][
-                            camera_t - delta_time,
-                             :,
-                             :,
-                             1:2]))
+                        run_idx]['images']['left'][camera_t - delta_time,:,:,1:2]))
 
         list_camera_input.append(
             torch.from_numpy(
                 self.run_files[
-                    run_idx][
-                        'images'][
-                    'right'][
-                        camera_t - 1,
-                         :,
-                         :,
-                         1:2]))
+                    run_idx]['images']['right'][camera_t - 1,:,:,1:2]))
 
         list_camera_input.append(
             torch.from_numpy(
                 self.run_files[
-                    run_idx][
-                        'images'][
-                    'right'][
-                        camera_t,
-                         :,
-                         :,
-                         1:2]))
+                    run_idx]['images']['right'][camera_t,:,:,1:2]))
 
         camera_data = torch.cat(list_camera_input, 2)
         camera_data = camera_data.float() / 255. - 0.5
@@ -138,30 +139,36 @@ class ArucoDataset(data.Dataset):
         metadata_raw = self.run_files[run_idx]['run_labels']
         metadata = torch.FloatTensor(20, 11, 20)
         metadata[:] = 0.
-        if aruco_idx < 2:
-            metadata[2, :, :] = 1 # Direct
-        else:
-            metadata[1, :, :] = 1 # Follow
+
+        if aruco_idx < 2: # Direct
+            metadata[2, :, :] = 1.
+        else:  # Follow
+            metadata[1, :, :] = 1.
+        if aruco_idx % 2 == 0:  # Clockwise
+            metadata[5, :, :] = 1.
+        else:  # Counterclockwise
+            metadata[6, :, :] = 1.
 
         # Get Ground Truth
         steer = []
         motor = []
 
-        for i in range(0, self.stride * 10, self.stride):
-            steer.append(float(self.run_files[run_idx]['aruco_trajectories']['steer'][camera_t + i, aruco_idx]))
-        for i in range(0, self.stride * 10, self.stride):
-            motor.append(float((self.run_files[run_idx]['metadata']['motor'][camera_t + i])))
-        for i in range(0, self.stride * 20, self.stride):
+        steer.append(float(self.run_files[run_idx]['metadata'][aruco_key][0]))
+        for i in range(0, self.stride * 9, self.stride):
+            steer.append(0.)
+
+        motor.append(float(self.run_files[run_idx]['metadata']['motor'][0]))
+        for i in range(0, self.stride * 29, self.stride):
             motor.append(0.)
 
         final_ground_truth = torch.FloatTensor(steer + motor) / 99.
 
-        mask = torch.FloatTensor([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, # use all data
-                                  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, # no mask
-                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  # no mask
-                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0]) # no mask
+        mask = torch.FloatTensor([1, 0, 0, 0, 0, 0, 0, 0, 0, 0,  # ONLY VALIDATE ON ONE STEERING AND MOTOR
+                                  1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-        return final_camera_data, metadata, final_ground_truth
+        return final_camera_data, metadata, final_ground_truth, mask
 
     def __len__(self):
         return self.total_length
@@ -171,15 +178,14 @@ class ArucoDataset(data.Dataset):
             if global_index >= length:
                 return len(self.visible) - idx - 1, global_index - length + 7
 
-    def shuffle_runs(self):
-        shuffle(self.runs)
-
 if __name__ == '__main__':
-    train_dataset = ArucoDataset('/hostroot/data/dataset/bair_car_data_new_28April2017/',
-                            [], [])
+    train_dataset = Dataset('/hostroot/data/dataset/bair_car_data_new_28April2017', [], [])
     train_data_loader = torch.utils.data.DataLoader(train_dataset,
-                                                    batch_size=1,
-                                                    pin_memory=False)
-    
-    for camera_data in train_data_loader:
-	print camera_data
+                                                    batch_size=500,
+                                                    shuffle=False, pin_memory=False)
+    start = time.time()
+    for cam, meta, truth, mask in train_data_loader:
+        cur = time.time()
+        print(500./(cur - start))
+        start = cur
+        pass

--- a/Dataset.py
+++ b/Dataset.py
@@ -36,7 +36,7 @@ class Dataset(data.Dataset):
             # Ignore invalid runs
             ignored = False
             for ignore in ignore_list:
-                if ignore in run_labels and run_labels[ignore]:
+                if ignore in run_labels and run_labels[ignore][0]:
                     ignored = True
                     break
             if ignored:
@@ -44,7 +44,7 @@ class Dataset(data.Dataset):
 
             ignored = len(require_one) > 0 
             for require in require_one:
-                if require in run_labels and run_labels[require]:
+                if require in run_labels and run_labels[require][0]:
                     ignored = False
                     break
             if ignored:

--- a/Parameters.py
+++ b/Parameters.py
@@ -13,8 +13,7 @@ parser.add_argument('--display', dest='display', action='store_true')
 parser.add_argument('--no-display', dest='display', action='store_false')
 parser.set_defaults(display=True)
 
-parser.add_argument('--verbose', default=True, type=bool,
-                    help='Debugging mode')
+parser.add_argument('--verbose', default=True, type=bool, help='Debugging mode')
 parser.add_argument('--aruco', default=True, type=bool, help='Use Aruco data')
 parser.add_argument('--data-path', default='/hostroot/home/dataset/' +
                     'bair_car_data', type=str)
@@ -50,6 +49,8 @@ parser.add_argument('--nsteps', default=10, type=int,
                     help='# of steps of time to predict in the future')
 parser.add_argument('--stride', default=10, type=int,
                     help="number of timesteps between network predictions")
+parser.add_argument('--log-interval', default=1, type=int,
+                    help="Number of batches in between logging")
 
 parser.add_argument('--print-moments', default=1000, type=int,
                     help='# of moments between printing stats')

--- a/Train.py
+++ b/Train.py
@@ -41,14 +41,14 @@ def main():
 
         net.train()  # Train mode
 
-        train_dataset = Dataset('/hostroot/data/dataset/bair_car_data_Main_Dataset', ARGS.require_one, ARGS.ignore_list)
+        train_dataset = Dataset('/hostroot/data/dataset/bair_car_data_Main_Dataset', ARGS.require_one, ARGS.ignore)
         train_data_loader = torch.utils.data.DataLoader(train_dataset,
                                                         batch_size=500,
                                                         shuffle=False, pin_memory=False)
 
         train_loss = Utils.LossLog()
 
-        for camera, meta, truth, mask in train_data_loader:
+        for batch_idx, (camera, meta, truth, mask) in enumerate(train_data_loader):
             # Cuda everything
             camera = camera.cuda()
             meta = meta.cuda()
@@ -73,19 +73,24 @@ def main():
             # Logging Loss
             train_loss.add(loss.data[0])
 
+	    print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+		epoch, batch_idx * len(camera), len(train_data_loader.dataset),
+		100. * batch_idx / len(train_data_loader), loss.data[0]))
+
+
         Utils.csvwrite('trainloss.csv', [train_loss.average()])
 
         logging.debug('Finished training epoch #{}'.format(epoch))
         logging.debug('Starting validation epoch #{}'.format(epoch))
 
-        val_dataset = Dataset('/hostroot/data/dataset/bair_car_data_Main_Dataset', ARGS.require_one, ARGS.ignore_list)
+        val_dataset = Dataset('/hostroot/data/dataset/bair_car_data_Main_Dataset', ARGS.require_one, ARGS.ignore)
         val_data_loader = torch.utils.data.DataLoader(val_dataset,
                                                         batch_size=500,
                                                         shuffle=False, pin_memory=False)
 
         val_loss = Utils.LossLog()
 
-        for camera, meta, truth, mask in val_data_loader:
+        for batch_idx, (camera, meta, truth, mask) in enumerate(val_data_loader):
             # Cuda everything
             camera = camera.cuda()
             meta = meta.cuda()
@@ -104,6 +109,10 @@ def main():
 
             # Logging Loss
             val_loss.add(loss.data[0])
+
+	    print('Val Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+		epoch, batch_idx * len(camera), len(val_data_loader.dataset),
+		100. * batch_idx / len(val_data_loader), loss.data[0]))
 
         Utils.csvwrite('valloss.csv', [val_loss.average()])
 

--- a/Train.py
+++ b/Train.py
@@ -2,9 +2,11 @@
 import sys
 import traceback
 import logging
+import time
 
 from Parameters import ARGS
-from Dataset import Dataset
+# from Dataset import Dataset
+from ArucoDataset import Dataset
 import Utils
 
 import matplotlib.pyplot as plt
@@ -41,13 +43,13 @@ def main():
 
         net.train()  # Train mode
 
-        train_dataset = Dataset('/hostroot/data/dataset/bair_car_data_Main_Dataset', ARGS.require_one, ARGS.ignore)
+        train_dataset = Dataset('/hostroot/data/dataset/bair_car_data_new_28April2017', ARGS.require_one, ARGS.ignore)
         train_data_loader = torch.utils.data.DataLoader(train_dataset,
                                                         batch_size=500,
                                                         shuffle=False, pin_memory=False)
 
         train_loss = Utils.LossLog()
-
+        start = time.time()
         for batch_idx, (camera, meta, truth, mask) in enumerate(train_data_loader):
             # Cuda everything
             camera = camera.cuda()
@@ -77,13 +79,17 @@ def main():
 		epoch, batch_idx * len(camera), len(train_data_loader.dataset),
 		100. * batch_idx / len(train_data_loader), loss.data[0]))
 
+            cur = time.time()
+            print(500./(cur - start))
+            start = cur
+
 
         Utils.csvwrite('trainloss.csv', [train_loss.average()])
 
         logging.debug('Finished training epoch #{}'.format(epoch))
         logging.debug('Starting validation epoch #{}'.format(epoch))
 
-        val_dataset = Dataset('/hostroot/data/dataset/bair_car_data_Main_Dataset', ARGS.require_one, ARGS.ignore)
+        val_dataset = Dataset('/hostroot/data/dataset/bair_car_data_new_28April2017', ARGS.require_one, ARGS.ignore)
         val_data_loader = torch.utils.data.DataLoader(val_dataset,
                                                         batch_size=500,
                                                         shuffle=False, pin_memory=False)

--- a/preprocess/h5pytosegment.py
+++ b/preprocess/h5pytosegment.py
@@ -129,6 +129,5 @@ def process(run_name):
 if __name__ == '__main__':
     input_prefix = '/hostroot/data/dataset/bair_car_data_Main_Dataset/h5py/'
     run_names = next(os.walk(input_prefix))[1]
-    # run_names = ['direct_racing_Tilden_27Nov16_12h20m21s_Mr_Blue']
     pool = Pool(processes=10)
     pool.map(process, run_names)


### PR DESCRIPTION
**This code allows getting the Aruco dataset along with "fake steer" from the pkl files @karlzipser has collected**
- The network outputs the standard 40 things, but loss is only calculated for one steering and motor output.
Known Problems:
1. In this data the min segment size is smaller (10 time-steps) so there are a LOT of segments. This can lead to slow loading times, for testing code with a smaller dataset, you can write a break statement after a certain number of runs has passed in the ArucoDataset.py code.
2. The python script does not handle run label generation so they have to be manually copied into the new dataset from the h5py data (currently use some clever bash commands and feed into vim to do this quickly). This was done for speed of coding, not for long term maintainability so it should be added to the script when there is time.